### PR TITLE
Speed up sync_fofb.py with wait_for_connection.

### DIFF
--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -18,7 +18,7 @@ import sys
 import bpm_epics_ioc_slot_mapping
 
 # configurable options
-time_frame_len_val = 5000
+time_frame_len_val = 2000
 
 # fixed options
 fofb_ctrl_offs = 480

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -38,7 +38,7 @@ cc_enable_crates = crates
 cc_enable_slots = [rtmlamp_slot, 13, 14, 17, 18]
 # exception for faulty crate:
 def cc_enable_exception(slot, crate):
-	return crate == '05' and slot in [15,16,19,20]
+	return False
 
 def consume(iterator):
 	collections.deque(iterator, maxlen=0)

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -17,18 +17,21 @@ import sys
 
 import bpm_epics_ioc_slot_mapping
 
-rtmlamp_slot = 3
+# configurable options
+time_frame_len_val = 5000
+
+# fixed options
 fofb_ctrl_offs = 480
-
-crates = [f"{int(i):02}" for i in sys.argv[1:]]
-# FOFB and BPMs slot number (physical_slot*2-1)
-
-# XXX: is this slot sequence correct?
-slots = [rtmlamp_slot, 13, 14, 15, 16, 17, 18, 19, 20]
-
 trigger_chans = [1, 2, 20]
 
-time_frame_len_val = 5000
+# format crate numbers taken from CLI args
+crates = [f"{int(i):02}" for i in sys.argv[1:]]
+
+# slot information
+rtmlamp_slot = 3
+# FOFB and BPMs slot numbers (physical_slot*2-1 and physical_slot*2)
+slots = [rtmlamp_slot, 13, 14, 15, 16, 17, 18, 19, 20]
+
 
 def consume(iterator):
 	collections.deque(iterator, maxlen=0)

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -127,4 +127,5 @@ put_pv(rcv_in_sel, 5, wait=False)
 wait_pv(chain(rcv_src, rcv_in_sel))
 
 evg_evt10 = PV("AS-RaMO:TI-EVG:Evt10ExtTrig-Cmd")
-evg_evt10.put("ON", wait=True)
+# doesn't return "ON"
+put_pv([evg_evt10], "ON", check=False)

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -96,6 +96,8 @@ rcv_in_sel = []
 bpm_id_list = []
 bpm_id = {}
 
+bpm_cnt = []
+
 for key in product(crates, slots):
 	crate, slot = key
 
@@ -113,6 +115,9 @@ for key in product(crates, slots):
 		for trigger in trigger_chans:
 			rcv_src.extend([create_pv(pv_prefix + "TRIGGER" + str(trigger) + "RcvSrc-Sel")])
 			rcv_in_sel.extend([create_pv(pv_prefix + "TRIGGER" + str(trigger) + "RcvInSel-SP")])
+
+	if slot == rtmlamp_slot and crate in cc_enable_crates:
+		bpm_cnt.extend(fofb_ctrl_pv_list_gen("BPMCnt-Mon", slot, crate))
 
 print("Connecting to all PVs...")
 consume((pv.wait_for_connection() for pv in global_pv_list))
@@ -147,3 +152,7 @@ print("Sending trigger event...")
 evg_evt10 = PV("AS-RaMO:TI-EVG:Evt10ExtTrig-Cmd")
 # doesn't return "ON"
 put_pv([evg_evt10], "ON", check=False)
+
+sleep(1)
+for pv in bpm_cnt:
+	print(f"{pv.pvname}: {pv.get(use_monitor=False)}")

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -10,6 +10,7 @@ Modified by: Érico Nogueira, Guilherme Ricioli
 
 from time import sleep
 from epics import PV
+import collections
 import numpy as np
 import sys
 
@@ -26,6 +27,17 @@ slots = [rtmlamp_slot, 13, 15, 17, 19]
 
 trigger_chans = [1, 2, 20]
 
+time_frame_len_val = 5000
+
+def consume(iterator):
+	collections.deque(iterator, maxlen=0)
+
+global_pv_list = []
+def create_pv(name):
+	pv = PV(name)
+	global_pv_list.append(pv)
+	return pv
+
 def pv_prefix_gen(slot, crate):
 	pv_prefix = ""
 	if slot == rtmlamp_slot:
@@ -40,15 +52,10 @@ def pv_prefix_gen(slot, crate):
 
 def fofb_ctrl_pv_list_gen(name, slot, crate):
 	pv_prefix = pv_prefix_gen(slot, crate)
-	pv_list = [PV(pv_prefix + "DCCP2P" + name)]
+	pv_list = [create_pv(pv_prefix + "DCCP2P" + name)]
 	if slot == rtmlamp_slot:
 		# has additional FOFB_CC core
-		pv_list.append(PV(pv_prefix + "DCCFMC" + name))
-
-	for pv in pv_list:
-		success = pv.wait_for_connection(5)
-		if not success:
-			raise RuntimeError(f"connection to '{pv.pvname}' wasn't successful")
+		pv_list.append(create_pv(pv_prefix + "DCCFMC" + name))
 
 	return pv_list
 
@@ -64,36 +71,50 @@ def put_pv(pv_list, value):
 			print(f"{pv.info}")
 			raise RuntimeError(f"writing into '{pv.pvname}' wasn't successful: '{new_value}' != '{value}'")
 
+cc_enable = {}
+bpm_id = {}
+time_frame_len = {}
+rcv_src = {}
+rcv_in_sel = {}
+for crate in crates:
+	for slot in slots:
+		key = (crate, slot)
+		cc_enable[key] = fofb_ctrl_pv_list_gen("CCEnable-SP", slot, crate)
+		bpm_id[key] = fofb_ctrl_pv_list_gen("BPMId-SP", slot, crate)
+		time_frame_len[key] = fofb_ctrl_pv_list_gen("TimeFrameLen-SP", slot, crate)
+
+		pv_prefix = pv_prefix_gen(slot, crate)
+		if slot != rtmlamp_slot:
+			rcv_src[key] = []
+			rcv_in_sel[key] = []
+			for trigger in trigger_chans:
+				rcv_src[key].extend([create_pv(pv_prefix + "TRIGGER" + str(trigger) + "RcvSrc-Sel")])
+				rcv_in_sel[key].extend([create_pv(pv_prefix + "TRIGGER" + str(trigger) + "RcvInSel-SP")])
+
+consume((pv.wait_for_connection() for pv in global_pv_list))
+
 for crate in crates:
 	print(f"Configuring crate {crate}...")
 
 	for slot in slots:
-		pv_prefix = pv_prefix_gen(slot, crate)
-		phys_slot = (slot + 1) // 2
+		key = (crate, slot)
 
-		cc_enable = fofb_ctrl_pv_list_gen("CCEnable-SP", slot, crate)
-		bpm_id = fofb_ctrl_pv_list_gen("BPMId-SP", slot, crate)
-		time_frame_len = fofb_ctrl_pv_list_gen("TimeFrameLen-SP", slot, crate)
-
-		put_pv(cc_enable, 0)
-
-		put_pv(time_frame_len, 5000)
+		put_pv(cc_enable[key], 0)
+		put_pv(time_frame_len[key], time_frame_len_val)
 
 		bpm_id_value = None
+		phys_slot = (slot + 1) // 2
 		if slot == rtmlamp_slot:
 			bpm_id_value = fofb_ctrl_offs + int(crate) - 1
 		else:
 			bpm_id_value = 8*(int(crate) - 1) + 2*(phys_slot - 7)
-		put_pv(bpm_id, bpm_id_value)
+		put_pv(bpm_id[key], bpm_id_value)
 
-		put_pv(cc_enable, 1)
+		put_pv(cc_enable[key], 1)
 
 		if slot != rtmlamp_slot:
-			for trigger in trigger_chans:
-				rcv_src = [PV(pv_prefix + "TRIGGER" + str(trigger) + "RcvSrc-Sel")]
-				rcv_in_sel = [PV(pv_prefix + "TRIGGER" + str(trigger) + "RcvInSel-SP")]
-				put_pv(rcv_src, 0)
-				put_pv(rcv_in_sel, 5)
+			put_pv(rcv_src[key], 0)
+			put_pv(rcv_in_sel[key], 5)
 
 evg_evt10 = PV("AS-RaMO:TI-EVG:Evt10ExtTrig-Cmd")
 evg_evt10.put("ON", wait=True)

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -100,14 +100,16 @@ for key in product(crates, slots):
 			rcv_src.extend([create_pv(pv_prefix + "TRIGGER" + str(trigger) + "RcvSrc-Sel")])
 			rcv_in_sel.extend([create_pv(pv_prefix + "TRIGGER" + str(trigger) + "RcvInSel-SP")])
 
+print("Connecting to all PVs...")
 consume((pv.wait_for_connection() for pv in global_pv_list))
 
+print("Disabling DCC and configuring TimeFrameLen...")
 put_pv(cc_enable, 0)
 put_pv(time_frame_len, time_frame_len_val, wait=False)
 
 for key in product(crates, slots):
 	crate, slot = key
-	print(f"Configuring crate {crate}...")
+	print(f"Writing BPM IDs for {crate}...")
 
 	bpm_id_value = None
 	phys_slot = (slot + 1) // 2
@@ -120,12 +122,14 @@ for key in product(crates, slots):
 
 wait_pv(chain(time_frame_len, bpm_id_list))
 
+print("Enabling DCC and configuring timer muxes...")
 put_pv(cc_enable, 1)
 
 put_pv(rcv_src, 0, wait=False)
 put_pv(rcv_in_sel, 5, wait=False)
 wait_pv(chain(rcv_src, rcv_in_sel))
 
+print("Sending trigger event...")
 evg_evt10 = PV("AS-RaMO:TI-EVG:Evt10ExtTrig-Cmd")
 # doesn't return "ON"
 put_pv([evg_evt10], "ON", check=False)

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -24,7 +24,7 @@ crates = [f"{int(i):02}" for i in sys.argv[1:]]
 # FOFB and BPMs slot number (physical_slot*2-1)
 
 # XXX: is this slot sequence correct?
-slots = [rtmlamp_slot, 13, 15, 17, 19]
+slots = [rtmlamp_slot, 13, 14, 15, 16, 17, 18, 19, 20]
 
 trigger_chans = [1, 2, 20]
 

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -18,7 +18,7 @@ import sys
 import bpm_epics_ioc_slot_mapping
 
 # configurable options
-time_frame_len_val = 2000
+time_frame_len_val = 2100
 
 # fixed options
 fofb_ctrl_offs = 480
@@ -33,9 +33,9 @@ rtmlamp_slot = 3
 slots = [rtmlamp_slot, 13, 14, 15, 16, 17, 18, 19, 20]
 
 # devices whose CC core will be enabled:
-# we only need M1/M2 for normal operation
+# we only need M1/M2 and C2/C3-1 for normal operation
 cc_enable_crates = crates
-cc_enable_slots = [rtmlamp_slot, 13, 14]
+cc_enable_slots = [rtmlamp_slot, 13, 14, 17, 18]
 # exception for faulty crate:
 def cc_enable_exception(slot, crate):
 	return crate == '05' and slot in [15,16,19,20]


### PR DESCRIPTION
This is following Ana's (@anacso17) recommendations for using wait_for_connection() for all PVs (though we skip the single EVG one that's the last step of the script).

The consume() function came from [1] as a clean way to loop through all members of the function with a list comprehension and without wasting memory.

Since we are here, also make the time_frame_len value a variable that's set at the top of the script.

Results (reproducible) for runtime were:

Before this commit:

    real    0m55.601s
    user    0m7.838s
    sys     0m0.810s

With this commit:

    real    0m27.843s
    user    0m4.902s
    sys     0m0.676s

[1] https://stackoverflow.com/questions/50937966/fastest-most-pythonic-way-to-consume-an-iterator