### PR TITLE
sync_fofb: use readback PVs to check values.

### DIFF
--- a/scripts/sync_fofb/pvs.py
+++ b/scripts/sync_fofb/pvs.py
@@ -9,20 +9,34 @@ import collections
 
 timeout = 10
 
+PVPair = collections.namedtuple('PVPair', ['sp', 'rb'])
+
 def _consume(iterator):
 	collections.deque(iterator, maxlen=0)
 
 # list of PV
 _global_pv_list = []
 def create_pv(name):
-	pv = PV(name)
-	_global_pv_list.append(pv)
-	return pv
+	sp = PV(name)
+	if name.endswith('-SP'):
+		rb = PV(name.removesuffix('SP') + 'RB')
+	elif name.endswith('-Sel'):
+		rb = PV(name.removesuffix('Sel') + 'Sts')
+	else:
+		# covers -Cmd and any other weird cases
+		rb = None
+	pv_pair = PVPair(sp, rb)
+
+	_global_pv_list.append(sp)
+	if rb is not None:
+		_global_pv_list.append(rb)
+
+	return pv_pair
 
 def wait_for_pv_connection():
 	_consume((pv.wait_for_connection() for pv in _global_pv_list))
 
-# list of ([PV], value)
+# list of ([PVPair], value)
 _global_wait_list = []
 
 def _wait_pv(wait_list):
@@ -30,20 +44,22 @@ def _wait_pv(wait_list):
 	waiting = True
 	while waiting:
 		sleep(0.001)
-		waiting = not all((pv.put_complete for pv_list, _ in wait_list for pv in pv_list))
+		waiting = not all((pv_pair.sp.put_complete for pv_list, _ in wait_list for pv_pair in pv_list))
 		if waiting and clock_gettime(CLOCK_MONOTONIC) - start_time > timeout:
 			for pv_list, _ in wait_list:
-				for pv in pv_list:
-					if not pv.put_complete:
-						print(f'Writing into {pv.pvname} taking too long...')
+				for pv_pair in pv_list:
+					if not pv_pair.sp.put_complete:
+						print(f'Writing into {pv_pair.sp.pvname} taking too long...')
 			raise Exception('PV write timeout')
 
 	for pv_list, value in wait_list:
 		if value is None:
 			continue
-		for pv in pv_list:
-			# TODO: look at readback PVs
-			assert pv.get() == value
+		for pv_pair in pv_list:
+			if pv_pair.rb is not None:
+				assert pv_pair.rb.get() == value
+			else:
+				assert pv_pair.sp.get() == value
 
 	if wait_list is _global_wait_list:
 		_global_wait_list[:] = []
@@ -52,9 +68,9 @@ def wait_pv():
 	_wait_pv(_global_wait_list)
 
 def put_pv(pv_list, value, wait=True, check=True):
-	for pv in pv_list:
-		print(f"Writing '{value}' into '{pv.pvname}'...")
-		pv.put(value, use_complete=True)
+	for pv_pair in pv_list:
+		print(f"Writing '{value}' into '{pv_pair.sp.pvname}'...")
+		pv_pair.sp.put(value, use_complete=True)
 
 	wait = (pv_list, value if check else None)
 
@@ -62,3 +78,11 @@ def put_pv(pv_list, value, wait=True, check=True):
 		_wait_pv([wait])
 	else:
 		_global_wait_list.append(wait)
+
+def print_pv(pv_list, which='sp'):
+	for pv_pair in pv_list:
+		if which == 'sp':
+			pv = pv_pair.sp
+		else:
+			pv = pv_pair.rb
+		print(f"{pv.pvname}: {pv.get(use_monitor=False)}")

--- a/scripts/sync_fofb/sync_fofb.py
+++ b/scripts/sync_fofb/sync_fofb.py
@@ -13,7 +13,7 @@ from time import sleep
 import numpy as np
 import sys
 
-from pvs import create_pv, wait_for_pv_connection, wait_pv, put_pv
+from pvs import create_pv, wait_for_pv_connection, wait_pv, put_pv, print_pv
 from sirius import rtmlamp_slot, slots_by_crate, crate_number, get_pv_prefix, get_fofb_cc_pv_list
 
 # configurable options
@@ -104,5 +104,4 @@ print("Sending trigger event...")
 put_pv([evg_evt10], "ON", check=False)
 
 sleep(1)
-for pv in bpm_cnt:
-	print(f"{pv.pvname}: {pv.get(use_monitor=False)}")
+print_pv(bpm_cnt)


### PR DESCRIPTION
Switch from using PV objects and instead use PVPair objects with setpoint and readback members. The global list still uses individual PVs, for ease of looping through them.

This required adding a print_pv() function to be used for diagnostics. For now, we are using the 'sp' field in PVPair for '-Mon' PVs, even if it isn't exactly coherent; it's working as the "main" field as well.