### PR TITLE
install_docker: add script.

### DIFF
--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+. crate_list.sh
+
+for crate in "${CRATES[@]}"; do
+    ssh root@${crate} "
+        echo $crate &&
+        yum -y install docker docker-compose &&
+        sed -i s/--selinux-enabled/--selinux-enabled=false/ /etc/sysconfig/docker &&
+        systemctl enable --now docker" &
+done

--- a/scripts/update_bpm_iocs.sh
+++ b/scripts/update_bpm_iocs.sh
@@ -8,41 +8,20 @@ fi
 
 COMMIT_ID=$1
 
-CRATES=()
-CRATES+=("IA-01RaBPM-CO-IOCSrv")
-CRATES+=("IA-02RaBPM-CO-IOCSrv")
-CRATES+=("IA-03RaBPM-CO-IOCSrv")
-CRATES+=("IA-04RaBPM-CO-IOCSrv")
-CRATES+=("IA-05RaBPM-CO-IOCSrv")
-CRATES+=("IA-06RaBPM-CO-IOCSrv")
-CRATES+=("IA-07RaBPM-CO-IOCSrv")
-CRATES+=("IA-08RaBPM-CO-IOCSrv")
-CRATES+=("IA-09RaBPM-CO-IOCSrv")
-CRATES+=("IA-10RaBPM-CO-IOCSrv")
-CRATES+=("IA-11RaBPM-CO-IOCSrv")
-CRATES+=("IA-12RaBPM-CO-IOCSrv")
-CRATES+=("IA-13RaBPM-CO-IOCSrv")
-CRATES+=("IA-14RaBPM-CO-IOCSrv")
-CRATES+=("IA-15RaBPM-CO-IOCSrv")
-CRATES+=("IA-16RaBPM-CO-IOCSrv")
-CRATES+=("IA-17RaBPM-CO-IOCSrv")
-CRATES+=("IA-18RaBPM-CO-IOCSrv")
-CRATES+=("IA-19RaBPM-CO-IOCSrv")
-CRATES+=("IA-20RaBPM-CO-IOCSrv")
-CRATES+=("IA-20RaBPMTL-CO-IOCSrv")
+. ./crate_list.sh
 
 for crate in "${CRATES[@]}"; do
-
-    SSHPASS=root sshpass -e ssh -o StrictHostKeyChecking=no root@${crate} bash -c "\
+    ssh root@${crate} "
         set -x && \
         mkdir -p /opt/epics/ioc && \
         cd /opt/epics/ioc && \
         (git clone https://github.com/lnls-dig/bpm-epics-ioc || (cd bpm-epics-ioc && git fetch --all)) && \
         cd /opt/epics/ioc/bpm-epics-ioc && \
+        systemctl stop halcs-ioc@{7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}.target && \
+        cp /etc/sysconfig/bpm-epics-ioc /home/lnls-bpm/bpm-epics-ioc.temp && \
+        make uninstall && \
         git reset --hard ${COMMIT_ID} && \
         git checkout -b stable-\$(date +%Y%m%d-%H%M%S) && \
-        cp /etc/sysconfig/bpm-epics-ioc /home/lnls-bpm/bpm-epics-ioc.temp && \
-        systemctl stop halcs-ioc@{7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}.target && \
         make clean && \
         make && \
         make install && \

--- a/scripts/update_rffe_iocs.sh
+++ b/scripts/update_rffe_iocs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ ! $# -eq 1 ]
+then
+    echo "Wrong usage! $0 <BRANCH>"
+    exit
+fi
+
+BRANCH=$1
+
+. crate_list.sh
+
+# TODO: restart containers with outdated base image
+
+for crate in "${CRATES[@]}"; do
+    ssh root@${crate} "
+        echo $crate
+        mkdir -p /opt/rffe-epics-ioc &&
+        cd /opt/rffe-epics-ioc && rm -f docker-compose.yml &&
+        wget https://raw.githubusercontent.com/lnls-dig/rffe-epics-ioc/${BRANCH}/deploy/docker-compose.yml &&
+        mkdir -p /var/opt/rffe-epics-ioc &&
+        docker-compose pull" &
+done


### PR DESCRIPTION
The version of Docker on our version of CentOS 7 doesn't deal with SELinux correctly, so we disable that integration.